### PR TITLE
Russian letter 'e' translation

### DIFF
--- a/src/Behat/Transliterator/Transliterator.php
+++ b/src/Behat/Transliterator/Transliterator.php
@@ -389,6 +389,7 @@ abstract class Transliterator
             }
 
             $newchar = $ord & 255;
+            // var_dump($c, $UTF8_TO_ASCII[$bank][$newchar], $newchar);
             if (array_key_exists($newchar, $UTF8_TO_ASCII[$bank])) {
                 $chars{$i} = $UTF8_TO_ASCII[$bank][$newchar];
             } else {

--- a/src/Behat/Transliterator/data/x04.php
+++ b/src/Behat/Transliterator/data/x04.php
@@ -3,7 +3,7 @@ $UTF8_TO_ASCII[0x04] = array(
 'Ie', 'Io', 'Dj', 'Gj', 'Ie', 'Dz', 'I', 'Yi', 'J', 'Lj', 'Nj', 'Tsh', 'Kj', 'I', 'U', 'Dzh',
 'A', 'B', 'V', 'G', 'D', 'Ie', 'Zh', 'Z', 'I', 'I', 'K', 'L', 'M', 'N', 'O', 'P',
 'R', 'S', 'T', 'U', 'F', 'Kh', 'Ts', 'Ch', 'Sh', 'Shch', '', 'Y', '\'', 'E', 'Iu', 'Ia',
-'a', 'b', 'v', 'gh', 'd', 'ie', 'zh', 'z', 'i', 'i', 'k', 'l', 'm', 'n', 'o', 'p',
+'a', 'b', 'v', 'gh', 'd', 'e', 'zh', 'z', 'i', 'i', 'k', 'l', 'm', 'n', 'o', 'p',
 'r', 's', 't', 'u', 'f', 'kh', 'ts', 'ch', 'sh', 'shch', '', 'y', '\'', 'e', 'iu', 'ia',
 'ie', 'io', 'dj', 'gj', 'ie', 'dz', 'i', 'yi', 'j', 'lj', 'nj', 'tsh', 'kj', 'i', 'u', 'dzh',
 'O', 'o', 'E', 'e', 'Ie', 'ie', 'E', 'e', 'Ie', 'ie', 'O', 'o', 'Io', 'io', 'Ks', 'ks',

--- a/src/Behat/Transliterator/data/x04.php
+++ b/src/Behat/Transliterator/data/x04.php
@@ -2,9 +2,9 @@
 $UTF8_TO_ASCII[0x04] = array(
 'Ie', 'Io', 'Dj', 'Gj', 'Ie', 'Dz', 'I', 'Yi', 'J', 'Lj', 'Nj', 'Tsh', 'Kj', 'I', 'U', 'Dzh',
 'A', 'B', 'V', 'G', 'D', 'Ie', 'Zh', 'Z', 'I', 'I', 'K', 'L', 'M', 'N', 'O', 'P',
-'R', 'S', 'T', 'U', 'F', 'Kh', 'Ts', 'Ch', 'Sh', 'Shch', '', 'Y', '\'', 'E', 'Iu', 'Ia',
-'a', 'b', 'v', 'gh', 'd', 'e', 'zh', 'z', 'i', 'i', 'k', 'l', 'm', 'n', 'o', 'p',
-'r', 's', 't', 'u', 'f', 'kh', 'ts', 'ch', 'sh', 'shch', '', 'y', '\'', 'e', 'iu', 'ia',
+'R', 'S', 'T', 'U', 'F', 'Kh', 'Ts', 'Ch', 'Sh', 'Shch', '', 'Y', '\'', 'E', 'Yu', 'Ya',
+'a', 'b', 'v', 'g', 'd', 'e', 'zh', 'z', 'i', 'i', 'k', 'l', 'm', 'n', 'o', 'p',
+'r', 's', 't', 'u', 'f', 'kh', 'ts', 'ch', 'sh', 'shch', '', 'y', '\'', 'e', 'yu', 'ya',
 'ie', 'io', 'dj', 'gj', 'ie', 'dz', 'i', 'yi', 'j', 'lj', 'nj', 'tsh', 'kj', 'i', 'u', 'dzh',
 'O', 'o', 'E', 'e', 'Ie', 'ie', 'E', 'e', 'Ie', 'ie', 'O', 'o', 'Io', 'io', 'Ks', 'ks',
 'Ps', 'ps', 'F', 'f', 'Y', 'y', 'Y', 'y', 'u', 'u', 'O', 'o', 'O', 'o', 'Ot', 'ot',

--- a/tests/TransliteratorTest.php
+++ b/tests/TransliteratorTest.php
@@ -21,10 +21,16 @@ class TransliteratorTest extends \PHPUnit_Framework_TestCase
             array('BonJour', 'BonJour'),
             array('Déjà', 'Deja'),
             array('trąnslįteration tėst ųsąge ūž', 'transliteration test usage uz'),
-            array('това е тестово заглавие', 'tova e testovo zaghlavie'),
-            array('это тестовый заголовок', 'eto testovyi zagholovok'),
+            array('това е тестово заглавие', 'tova e testovo zaglavie'),
+            array('это тестовый заголовок', 'eto testovyi zagolovok'),
             array('führen Aktivitäten Haglöfs', 'fuhren Aktivitaten Haglofs'),
-            array('тест', 'test')
+            array('тест', 'test'),
+            array('Розничная торговля', 'Roznichnaya torgovlya'),
+            array('Брест', 'Brest'),
+            array('резюме', 'rezyume'),
+            array('Промышленное производство', 'Promyshlennoe proizvodstvo'),
+            array('Оптовая торговля', 'Optovaya torgovlya'),
+            array('Я', 'Ya')
         );
     }
 
@@ -44,10 +50,15 @@ class TransliteratorTest extends \PHPUnit_Framework_TestCase
             array('BonJour & au revoir', 'bonjour-au-revoir'),
             array('Déjà', 'deja'),
             array('trąnslįteration tėst ųsąge ūž', 'transliteration-test-usage-uz'),
-            array('това е тестово заглавие', 'tova-e-testovo-zaghlavie'),
-            array('это тестовый заголовок', 'eto-testovyi-zagholovok'),
+            array('това е тестово заглавие', 'tova-e-testovo-zaglavie'),
+            array('это тестовый заголовок', 'eto-testovyi-zagolovok'),
             array('führen Aktivitäten Haglöfs', 'fuhren-aktivitaten-haglofs'),
-            array('тест', 'test')
+            array('тест', 'test'),
+            array('Розничная торговля', 'roznichnaya-torgovlya'),
+            array('Брест', 'brest'),
+            array('резюме', 'rezyume'),
+            array('Промышленное производство', 'promyshlennoe-proizvodstvo'),
+            array('Оптовая торговля', 'optovaya-torgovlya')
         );
     }
 

--- a/tests/TransliteratorTest.php
+++ b/tests/TransliteratorTest.php
@@ -21,9 +21,10 @@ class TransliteratorTest extends \PHPUnit_Framework_TestCase
             array('BonJour', 'BonJour'),
             array('Déjà', 'Deja'),
             array('trąnslįteration tėst ųsąge ūž', 'transliteration test usage uz'),
-            array('това е тестово заглавие', 'tova ie tiestovo zaghlaviie'),
-            array('это тестовый заголовок', 'eto tiestovyi zagholovok'),
+            array('това е тестово заглавие', 'tova e testovo zaghlavie'),
+            array('это тестовый заголовок', 'eto testovyi zagholovok'),
             array('führen Aktivitäten Haglöfs', 'fuhren Aktivitaten Haglofs'),
+            array('тест', 'test')
         );
     }
 
@@ -43,9 +44,10 @@ class TransliteratorTest extends \PHPUnit_Framework_TestCase
             array('BonJour & au revoir', 'bonjour-au-revoir'),
             array('Déjà', 'deja'),
             array('trąnslįteration tėst ųsąge ūž', 'transliteration-test-usage-uz'),
-            array('това е тестово заглавие', 'tova-ie-tiestovo-zaghlaviie'),
-            array('это тестовый заголовок', 'eto-tiestovyi-zagholovok'),
+            array('това е тестово заглавие', 'tova-e-testovo-zaghlavie'),
+            array('это тестовый заголовок', 'eto-testovyi-zagholovok'),
             array('führen Aktivitäten Haglöfs', 'fuhren-aktivitaten-haglofs'),
+            array('тест', 'test')
         );
     }
 
@@ -64,6 +66,7 @@ class TransliteratorTest extends \PHPUnit_Framework_TestCase
             array('BonJour', 'BonJour'),
             array('Déjà', 'Deja'),
             array('това е тестово заглавие', 'това е тестово заглавие'),
+            array('тест', 'тест')
         );
     }
 


### PR DESCRIPTION
As addressed on #4 issue, there is a problem with Russian 'e' letter conversion to latin.

Examples would be with - _тест_ (word), _Брест_ (city in Belarus).

In order to fix this issue, I had to modify current test examples with Russian words.

To prove that my assertions were correct I've used online transliterator tools such as http://translit-online.ru/ & http://translate.google.com.

So phrase `това е тестово заглавие` with online transliterator would be `tova e testovo zaglavie`.

![transliterator](https://cloud.githubusercontent.com/assets/123205/12903302/68f7083a-cecf-11e5-9815-3de2bf91e5ca.png)

![g_transliterator](https://cloud.githubusercontent.com/assets/123205/12903478/8b6046a6-ced0-11e5-9b28-5f8c79a2849e.png)

I would presume that older russian test cases were written no by russian guy :)

Thank you for reviewing my PR & if you have any questions or should do anything else - please write.