### PR TITLE
Stop \Behat\Transliterator\Transliterator::postProcessText() breaking words containing apostrophes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## [Unreleased]
+### Added
+  * [Behat/Behat#976](https://github.com/Behat/Transliterator/pull/18): Stop \Behat\Transliterator\Transliterator::postProcessText() breaking words containing apostrophes
+
 1.1.0 / 2015-09-28
 ==================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 
-## [Unreleased]
-### Added
-  * [Behat/Behat#976](https://github.com/Behat/Transliterator/pull/18): Stop \Behat\Transliterator\Transliterator::postProcessText() breaking words containing apostrophes
+
+1.2.0 / 2017-03-??
+==================
+
+  * Stop Transliterator::postProcessText() breaking words containing apostrophes
 
 1.1.0 / 2015-09-28
 ==================

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "license":      "Artistic-1.0",
 
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "phpunit/phpunit": "~4.5"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
 
     "require-dev": {
         "php-yaoi/php-yaoi": "^1.0",
-        "chuyskywalker/rolling-curl": "^3.1",
-        "phpunit/phpunit": "~4.5"
+        "chuyskywalker/rolling-curl": "^3.1"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
     "license":      "Artistic-1.0",
 
     "require": {
-        "php": ">=5.3.3",
-        "phpunit/phpunit": "~4.5"
+        "php": ">=5.3.3"
     },
 
     "require-dev": {
         "php-yaoi/php-yaoi": "^1.0",
-        "chuyskywalker/rolling-curl": "^3.1"
+        "chuyskywalker/rolling-curl": "^3.1",
+        "phpunit/phpunit": "~4.5"
     },
 
     "autoload": {

--- a/src/Behat/Transliterator/Transliterator.php
+++ b/src/Behat/Transliterator/Transliterator.php
@@ -574,7 +574,7 @@ abstract class Transliterator
         }
 
         // Remove apostrophes which are not used as quotes around a string
-        $text = preg_replace('|(\\w)\'(\\w)|', '${1}${2}', $text);
+        $text = preg_replace('/(\\w)\'(\\w)/', '${1}${2}', $text);
 
         // Replace all none word characters with a space
         $text = preg_replace('/\W/', ' ', $text);

--- a/src/Behat/Transliterator/Transliterator.php
+++ b/src/Behat/Transliterator/Transliterator.php
@@ -573,7 +573,10 @@ abstract class Transliterator
             $text = strtolower($text);
         }
 
-        // Remove all none word characters
+        // Remove apostrophes which are not used as quotes around a string
+        $text = preg_replace('|(\\w)(\')(\\w)|', '${1}${3}', $text);
+
+        // Replace all none word characters with a space
         $text = preg_replace('/\W/', ' ', $text);
 
         // More stripping. Replace spaces with dashes

--- a/src/Behat/Transliterator/Transliterator.php
+++ b/src/Behat/Transliterator/Transliterator.php
@@ -574,7 +574,7 @@ abstract class Transliterator
         }
 
         // Remove apostrophes which are not used as quotes around a string
-        $text = preg_replace('|(\\w)(\')(\\w)|', '${1}${3}', $text);
+        $text = preg_replace('|(\\w)\'(\\w)|', '${1}${2}', $text);
 
         // Replace all none word characters with a space
         $text = preg_replace('/\W/', ' ', $text);

--- a/tests/TransliteratorTest.php
+++ b/tests/TransliteratorTest.php
@@ -46,7 +46,7 @@ class TransliteratorTest extends \PHPUnit_Framework_TestCase
             array('това е тестово заглавие', 'tova-e-testovo-zaglavie'),
             array('это тестовый заголовок', 'eto-testovyi-zagolovok'),
             array('führen Aktivitäten Haglöfs', 'fuhren-aktivitaten-haglofs'),
-            array('that it\'s \'eleven\' \'o\'clock\'', 'that-its-eleven-oclock'),
+            array("that it's 'eleven' 'o'clock'", "that-its-eleven-oclock"),
         );
     }
 

--- a/tests/TransliteratorTest.php
+++ b/tests/TransliteratorTest.php
@@ -46,6 +46,7 @@ class TransliteratorTest extends \PHPUnit_Framework_TestCase
             array('това е тестово заглавие', 'tova-e-testovo-zaglavie'),
             array('это тестовый заголовок', 'eto-testovyi-zagolovok'),
             array('führen Aktivitäten Haglöfs', 'fuhren-aktivitaten-haglofs'),
+            array('that it\'s \'eleven\' \'o\'clock\'', 'that-its-eleven-oclock'),
         );
     }
 


### PR DESCRIPTION
Addresses "Apostrophes causing unexpected capitals in snippets https://github.com/Behat/Behat/issues/976" with another PR on Behat/Behat (https://github.com/Behat/Behat/pull/1001).