### PR TITLE
PHP 7.4 deprecated curly brace syntax for array access

### DIFF
--- a/src/Behat/Transliterator/Transliterator.php
+++ b/src/Behat/Transliterator/Transliterator.php
@@ -354,26 +354,26 @@ abstract class Transliterator
         $chars = $ar[0];
 
         foreach ($chars as $i => $c) {
-            if (ord($c{0}) >= 0 && ord($c{0}) <= 127) {
+            if (ord($c[0]) >= 0 && ord($c[0]) <= 127) {
                 continue;
             } // ASCII - next please
-            if (ord($c{0}) >= 192 && ord($c{0}) <= 223) {
-                $ord = (ord($c{0}) - 192) * 64 + (ord($c{1}) - 128);
+            if (ord($c[0]) >= 192 && ord($c[0]) <= 223) {
+                $ord = (ord($c[0]) - 192) * 64 + (ord($c[1]) - 128);
             }
-            if (ord($c{0}) >= 224 && ord($c{0}) <= 239) {
-                $ord = (ord($c{0}) - 224) * 4096 + (ord($c{1}) - 128) * 64 + (ord($c{2}) - 128);
+            if (ord($c[0]) >= 224 && ord($c[0]) <= 239) {
+                $ord = (ord($c[0]) - 224) * 4096 + (ord($c[1]) - 128) * 64 + (ord($c[2]) - 128);
             }
-            if (ord($c{0}) >= 240 && ord($c{0}) <= 247) {
-                $ord = (ord($c{0}) - 240) * 262144 + (ord($c{1}) - 128) * 4096 + (ord($c{2}) - 128) * 64 + (ord($c{3}) - 128);
+            if (ord($c[0]) >= 240 && ord($c[0]) <= 247) {
+                $ord = (ord($c[0]) - 240) * 262144 + (ord($c[1]) - 128) * 4096 + (ord($c[2]) - 128) * 64 + (ord($c[3]) - 128);
             }
-            if (ord($c{0}) >= 248 && ord($c{0}) <= 251) {
-                $ord = (ord($c{0}) - 248) * 16777216 + (ord($c{1}) - 128) * 262144 + (ord($c{2}) - 128) * 4096 + (ord($c{3}) - 128) * 64 + (ord($c{4}) - 128);
+            if (ord($c[0]) >= 248 && ord($c[0]) <= 251) {
+                $ord = (ord($c[0]) - 248) * 16777216 + (ord($c[1]) - 128) * 262144 + (ord($c[2]) - 128) * 4096 + (ord($c[3]) - 128) * 64 + (ord($c[4]) - 128);
             }
-            if (ord($c{0}) >= 252 && ord($c{0}) <= 253) {
-                $ord = (ord($c{0}) - 252) * 1073741824 + (ord($c{1}) - 128) * 16777216 + (ord($c{2}) - 128) * 262144 + (ord($c{3}) - 128) * 4096 + (ord($c{4}) - 128) * 64 + (ord($c{5}) - 128);
+            if (ord($c[0]) >= 252 && ord($c[0]) <= 253) {
+                $ord = (ord($c[0]) - 252) * 1073741824 + (ord($c[1]) - 128) * 16777216 + (ord($c[2]) - 128) * 262144 + (ord($c[3]) - 128) * 4096 + (ord($c[4]) - 128) * 64 + (ord($c[5]) - 128);
             }
-            if (ord($c{0}) >= 254 && ord($c{0}) <= 255) {
-                $chars{$i} = $unknown;
+            if (ord($c[0]) >= 254 && ord($c[0]) <= 255) {
+                $chars[$i] = $unknown;
                 continue;
             } //error
 
@@ -390,9 +390,9 @@ abstract class Transliterator
 
             $newchar = $ord & 255;
             if (array_key_exists($newchar, $UTF8_TO_ASCII[$bank])) {
-                $chars{$i} = $UTF8_TO_ASCII[$bank][$newchar];
+                $chars[$i] = $UTF8_TO_ASCII[$bank][$newchar];
             } else {
-                $chars{$i} = $unknown;
+                $chars[$i] = $unknown;
             }
         }
 
@@ -460,7 +460,7 @@ abstract class Transliterator
 
         $len = strlen($str);
         for ($i = 0; $i < $len; ++$i) {
-            $in = ord($str{$i});
+            $in = ord($str[$i]);
             if ($mState == 0) {
                 // When mState is zero we expect either a US-ASCII character or a
                 // multi-octet sequence.


### PR DESCRIPTION
PHP 7.4 deprecated curly brace syntax for array access (detected by PHPCompatibility)